### PR TITLE
Allow for pinning a self signed cert

### DIFF
--- a/lib/telnet/web_client.ex
+++ b/lib/telnet/web_client.ex
@@ -57,6 +57,7 @@ defmodule Telnet.WebClient do
     |> Map.put(:type, Keyword.get(opts, :type))
     |> Map.put(:host, Keyword.get(opts, :host))
     |> Map.put(:port, Keyword.get(opts, :port))
+    |> Map.put(:certificate, Keyword.get(opts, :certificate))
     |> Map.put(:channel_pid, channel_pid)
     |> Map.put(:channel_buffer, <<>>)
   end


### PR DESCRIPTION
The cert is passed in from the web client, the self signed cert that is
returned from the server must match the known certificate.